### PR TITLE
Memory model fixes

### DIFF
--- a/lib/Target/AMDGPU/AMDGPU.h
+++ b/lib/Target/AMDGPU/AMDGPU.h
@@ -208,7 +208,10 @@ enum class AMDGPUSynchronizationScope : unsigned {
 
   /// Synchronized with respect to image fence instruction executing in the same
   /// work-item.
-  Image
+  Image,
+
+  /// Unknown synchronization scope.
+  Unknown
 };
 
 #endif

--- a/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
+++ b/lib/Target/AMDGPU/SIMemoryLegalizer.cpp
@@ -28,7 +28,7 @@ namespace {
 class SIMemoryLegalizer final : public MachineFunctionPass {
 private:
   /// \brief Immediate for "vmcnt(0)".
-  static constexpr unsigned Vmcnt0 = 0x7 << 4 | 0xF << 8;
+  static const unsigned Vmcnt0;
 
   /// \brief Target instruction info.
   const SIInstrInfo *TII;
@@ -106,6 +106,7 @@ public:
 
 INITIALIZE_PASS(SIMemoryLegalizer, DEBUG_TYPE, PASS_NAME, false, false)
 
+const unsigned SIMemoryLegalizer::Vmcnt0 = 0x7 << 4 | 0xF << 8;
 char SIMemoryLegalizer::ID = 0;
 char &llvm::SIMemoryLegalizerID = SIMemoryLegalizer::ID;
 


### PR DESCRIPTION
1) Fix MSVS13 build by switching from constexpr to just const
2) Fix switch-related warnings by adding an "Unknown" synchronization scope
