### PR TITLE
Bring AMDGPU memory model related bits in sync with phabricator reviews

### DIFF
--- a/include/llvm/Bitcode/LLVMBitCodes.h
+++ b/include/llvm/Bitcode/LLVMBitCodes.h
@@ -370,7 +370,7 @@ enum AtomicOrderingCodes {
 };
 
 /// Encoded SynchronizationScope values.
-enum AtomicSynchScopeCodes : unsigned {
+enum AtomicSynchScopeCodes : uint8_t {
   /// Encoded value for SingleThread synchronization scope.
   SYNCHSCOPE_SINGLETHREAD = 0,
 

--- a/include/llvm/IR/Instructions.h
+++ b/include/llvm/IR/Instructions.h
@@ -38,7 +38,7 @@ class DataLayout;
 class LLVMContext;
 
 /// Predefined synchronization scopes.
-enum SynchronizationScope : unsigned {
+enum SynchronizationScope : uint8_t {
   /// Synchronized with respect to signal handlers executing in the same thread.
   SingleThread = 0,
 

--- a/lib/AsmParser/LLLexer.cpp
+++ b/lib/AsmParser/LLLexer.cpp
@@ -541,7 +541,7 @@ lltok::Kind LLLexer::LexIdentifier() {
   KEYWORD(acq_rel);
   KEYWORD(seq_cst);
   KEYWORD(singlethread);
-  KEYWORD(synchscope);
+  KEYWORD(syncscope);
 
   KEYWORD(nnan);
   KEYWORD(ninf);

--- a/lib/AsmParser/LLParser.cpp
+++ b/lib/AsmParser/LLParser.cpp
@@ -1274,6 +1274,19 @@ bool LLParser::ParseStringConstant(std::string &Result) {
   return false;
 }
 
+/// ParseUInt8
+///   ::= uint8
+bool LLParser::ParseUInt8(uint8_t &Val) {
+  if (Lex.getKind() != lltok::APSInt || Lex.getAPSIntVal().isSigned())
+    return TokError("expected integer");
+  uint64_t Val64 = Lex.getAPSIntVal().getLimitedValue(0xFFULL+1);
+  if (Val64 != uint8_t(Val64))
+    return TokError("expected 8-bit integer (too large)");
+  Val = Val64;
+  Lex.Lex();
+  return false;
+}
+
 /// ParseUInt32
 ///   ::= uint32
 bool LLParser::ParseUInt32(uint32_t &Val) {
@@ -1888,7 +1901,7 @@ bool LLParser::parseAllocSizeArguments(unsigned &BaseSizeArg,
 
 /// ParseScopeAndOrdering
 ///   if isAtomic:
-///     ::= 'singlethread' or 'synchscope' '(' uint32 ')'? AtomicOrdering
+///     ::= 'singlethread' or 'syncscope' '(' uint8 ')'? AtomicOrdering
 ///   else
 ///     ::=
 ///
@@ -1904,27 +1917,27 @@ bool LLParser::ParseScopeAndOrdering(bool isAtomic, SynchronizationScope &Scope,
 /// ParseScope
 ///   ::= /* empty */
 ///   ::= 'singlethread'
-///   ::= 'synchscope' '(' uint32 ')'
+///   ::= 'syncscope' '(' uint8 ')'
 ///
 /// This sets Scope to the parsed value.
 bool LLParser::ParseScope(SynchronizationScope &Scope) {
-  if (EatIfPresent(lltok::kw_synchscope)) {
+  if (EatIfPresent(lltok::kw_syncscope)) {
     auto StartParen = Lex.getLoc();
     if (!EatIfPresent(lltok::lparen))
-      return Error(StartParen, "expected '(' in synchscope");
+      return Error(StartParen, "expected '(' in syncscope");
 
-    unsigned ScopeU32 = 0;
-    auto ScopeU32At = Lex.getLoc();
-    if (ParseUInt32(ScopeU32))
+    uint8_t ScopeU8 = 0;
+    auto ScopeU8At = Lex.getLoc();
+    if (ParseUInt8(ScopeU8))
       return true;
-    if (ScopeU32 < SynchronizationScopeFirstTargetSpecific)
-      return Error(ScopeU32At, "invalid target specific synchronization scope");
+    if (ScopeU8 < SynchronizationScopeFirstTargetSpecific)
+      return Error(ScopeU8At, "invalid syncscope");
 
     auto EndParen = Lex.getLoc();
     if (!EatIfPresent(lltok::rparen))
-      return Error(EndParen, "expected ')' in synchscope");
+      return Error(EndParen, "expected ')' in syncscope");
 
-    Scope = SynchronizationScope(ScopeU32);
+    Scope = SynchronizationScope(ScopeU8);
     return false;
   }
 

--- a/lib/AsmParser/LLParser.h
+++ b/lib/AsmParser/LLParser.h
@@ -211,6 +211,11 @@ namespace llvm {
       return false;
     }
     bool ParseStringConstant(std::string &Result);
+    bool ParseUInt8(uint8_t &Val);
+    bool ParseUInt8(uint8_t &Val, LocTy &Loc) {
+      Loc = Lex.getLoc();
+      return ParseUInt8(Val);
+    }
     bool ParseUInt32(unsigned &Val);
     bool ParseUInt32(unsigned &Val, LocTy &Loc) {
       Loc = Lex.getLoc();

--- a/lib/AsmParser/LLToken.h
+++ b/lib/AsmParser/LLToken.h
@@ -94,7 +94,7 @@ enum Kind {
   kw_acq_rel,
   kw_seq_cst,
   kw_singlethread,
-  kw_synchscope,
+  kw_syncscope,
 
   kw_nnan,
   kw_ninf,

--- a/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -970,12 +970,14 @@ static AtomicOrdering getDecodedOrdering(unsigned Val) {
 }
 
 static SynchronizationScope getDecodedSynchScope(unsigned Val) {
-  if (Val >= bitc::SYNCHSCOPE_FIRSTTARGETSPECIFIC)
+  if (Val >= bitc::SYNCHSCOPE_FIRSTTARGETSPECIFIC) {
+    assert(Val == uint8_t(Val) && "expected 8-bit integer (too large)");
     return SynchronizationScope(SynchronizationScopeFirstTargetSpecific +
-      (Val - bitc::SYNCHSCOPE_FIRSTTARGETSPECIFIC));
+        (Val - bitc::SYNCHSCOPE_FIRSTTARGETSPECIFIC));
+  }
 
   switch (Val) {
-  default: llvm_unreachable("Invalid synch scope");
+  default: llvm_unreachable("Invalid syncscope");
   case bitc::SYNCHSCOPE_SINGLETHREAD: return SingleThread;
   case bitc::SYNCHSCOPE_CROSSTHREAD: return CrossThread;
   }

--- a/lib/Bitcode/Writer/BitcodeWriter.cpp
+++ b/lib/Bitcode/Writer/BitcodeWriter.cpp
@@ -592,10 +592,10 @@ static unsigned getEncodedOrdering(AtomicOrdering Ordering) {
 static unsigned getEncodedSynchScope(SynchronizationScope SynchScope) {
   if (SynchScope >= SynchronizationScopeFirstTargetSpecific)
     return unsigned(bitc::SYNCHSCOPE_FIRSTTARGETSPECIFIC +
-      (SynchScope - SynchronizationScopeFirstTargetSpecific));
+        (SynchScope - SynchronizationScopeFirstTargetSpecific));
 
   switch (SynchScope) {
-  default: llvm_unreachable("Invalid synch scope");
+  default: llvm_unreachable("Invalid syncscope");
   case SingleThread: return bitc::SYNCHSCOPE_SINGLETHREAD;
   case CrossThread: return bitc::SYNCHSCOPE_CROSSTHREAD;
   }

--- a/lib/CodeGen/MachineInstr.cpp
+++ b/lib/CodeGen/MachineInstr.cpp
@@ -542,13 +542,13 @@ MachineMemOperand::MachineMemOperand(MachinePointerInfo ptrinfo, Flags f,
                                      AtomicOrdering Ordering,
                                      AtomicOrdering FailureOrdering)
     : PtrInfo(ptrinfo), Size(s), FlagVals(f), BaseAlignLog2(Log2_32(a) + 1),
-      AAInfo(AAInfo), Ranges(Ranges), SynchScope(SynchScope),
-      Ordering(Ordering), FailureOrdering(FailureOrdering) {
+      AAInfo(AAInfo), Ranges(Ranges) {
   assert((PtrInfo.V.isNull() || PtrInfo.V.is<const PseudoSourceValue*>() ||
           isa<PointerType>(PtrInfo.V.get<const Value*>()->getType())) &&
          "invalid pointer value");
   assert(getBaseAlignment() == a && "Alignment is not a power of 2!");
   assert((isLoad() || isStore()) && "Not a load/store!");
+  InitAtomicInfo(SynchScope, Ordering, FailureOrdering);
 }
 
 /// Profile - Gather unique data for the object.

--- a/lib/Target/AMDGPU/AMDGPU.h
+++ b/lib/Target/AMDGPU/AMDGPU.h
@@ -181,7 +181,7 @@ enum AddressSpaces : unsigned {
 } // namespace AMDGPUAS
 
 /// AMDGPU-specific synchronization scopes.
-enum class AMDGPUSynchronizationScope : unsigned {
+enum class AMDGPUSynchronizationScope : uint8_t {
   /// Synchronized with respect to the entire system, which includes all
   /// work-items on all agents executing kernel dispatches for the same
   /// application process, together with all agents executing the same

--- a/test/Assembler/atomic.ll
+++ b/test/Assembler/atomic.ll
@@ -7,14 +7,14 @@ define void @f(i32* %x) {
   load atomic i32, i32* %x unordered, align 4
   ; CHECK: load atomic volatile i32, i32* %x singlethread acquire, align 4
   load atomic volatile i32, i32* %x singlethread acquire, align 4
-  ; CHECK: load atomic volatile i32, i32* %x synchscope(2) acquire, align 4
-  load atomic volatile i32, i32* %x synchscope(2) acquire, align 4
+  ; CHECK: load atomic volatile i32, i32* %x syncscope(2) acquire, align 4
+  load atomic volatile i32, i32* %x syncscope(2) acquire, align 4
   ; CHECK: store atomic i32 3, i32* %x release, align 4
   store atomic i32 3, i32* %x release, align 4
   ; CHECK: store atomic volatile i32 3, i32* %x singlethread monotonic, align 4
   store atomic volatile i32 3, i32* %x singlethread monotonic, align 4
-  ; CHECK: store atomic volatile i32 3, i32* %x synchscope(3) monotonic, align 4
-  store atomic volatile i32 3, i32* %x synchscope(3) monotonic, align 4
+  ; CHECK: store atomic volatile i32 3, i32* %x syncscope(3) monotonic, align 4
+  store atomic volatile i32 3, i32* %x syncscope(3) monotonic, align 4
   ; CHECK: cmpxchg i32* %x, i32 1, i32 0 singlethread monotonic monotonic
   cmpxchg i32* %x, i32 1, i32 0 singlethread monotonic monotonic
   ; CHECK: cmpxchg volatile i32* %x, i32 0, i32 1 acq_rel acquire
@@ -23,19 +23,19 @@ define void @f(i32* %x) {
   cmpxchg i32* %x, i32 42, i32 0 acq_rel monotonic
   ; CHECK: cmpxchg weak i32* %x, i32 13, i32 0 seq_cst monotonic
   cmpxchg weak i32* %x, i32 13, i32 0 seq_cst monotonic
-  ; CHECK: cmpxchg weak i32* %x, i32 13, i32 0 synchscope(4) seq_cst monotonic
-  cmpxchg weak i32* %x, i32 13, i32 0 synchscope(4) seq_cst monotonic
+  ; CHECK: cmpxchg weak i32* %x, i32 13, i32 0 syncscope(4) seq_cst monotonic
+  cmpxchg weak i32* %x, i32 13, i32 0 syncscope(4) seq_cst monotonic
   ; CHECK: atomicrmw add i32* %x, i32 10 seq_cst
   atomicrmw add i32* %x, i32 10 seq_cst
   ; CHECK: atomicrmw volatile xchg  i32* %x, i32 10 monotonic
   atomicrmw volatile xchg i32* %x, i32 10 monotonic
-  ; CHECK: atomicrmw volatile xchg i32* %x, i32 10 synchscope(5) monotonic
-  atomicrmw volatile xchg i32* %x, i32 10 synchscope(5) monotonic
+  ; CHECK: atomicrmw volatile xchg i32* %x, i32 10 syncscope(5) monotonic
+  atomicrmw volatile xchg i32* %x, i32 10 syncscope(5) monotonic
   ; CHECK: fence singlethread release
   fence singlethread release
   ; CHECK: fence seq_cst
   fence seq_cst
-  ; CHECK: fence synchscope(6) seq_cst
-  fence synchscope(6) seq_cst
+  ; CHECK: fence syncscope(6) seq_cst
+  fence syncscope(6) seq_cst
   ret void
 }

--- a/test/CodeGen/AMDGPU/memory-model-atomic-cmpxchg.ll
+++ b/test/CodeGen/AMDGPU/memory-model-atomic-cmpxchg.ll
@@ -117,7 +117,7 @@ define void @system_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @agent_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) monotonic monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) monotonic monotonic
   ret void
 }
 
@@ -128,7 +128,7 @@ define void @agent_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) acquire monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) acquire monotonic
   ret void
 }
 
@@ -139,7 +139,7 @@ define void @agent_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @agent_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) release monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) release monotonic
   ret void
 }
 
@@ -150,7 +150,7 @@ define void @agent_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) acq_rel monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) acq_rel monotonic
   ret void
 }
 
@@ -161,7 +161,7 @@ define void @agent_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) seq_cst monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) seq_cst monotonic
   ret void
 }
 
@@ -172,7 +172,7 @@ define void @agent_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) acquire acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) acquire acquire
   ret void
 }
 
@@ -183,7 +183,7 @@ define void @agent_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) release acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) release acquire
   ret void
 }
 
@@ -194,7 +194,7 @@ define void @agent_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) acq_rel acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) acq_rel acquire
   ret void
 }
 
@@ -205,7 +205,7 @@ define void @agent_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) seq_cst acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) seq_cst acquire
   ret void
 }
 
@@ -216,7 +216,7 @@ define void @agent_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(2) seq_cst seq_cst
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(2) seq_cst seq_cst
   ret void
 }
 
@@ -227,7 +227,7 @@ define void @agent_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) monotonic monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) monotonic monotonic
   ret void
 }
 
@@ -238,7 +238,7 @@ define void @work_group_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) acquire monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) acquire monotonic
   ret void
 }
 
@@ -249,7 +249,7 @@ define void @work_group_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) release monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) release monotonic
   ret void
 }
 
@@ -260,7 +260,7 @@ define void @work_group_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) acq_rel monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) acq_rel monotonic
   ret void
 }
 
@@ -271,7 +271,7 @@ define void @work_group_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) seq_cst monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) seq_cst monotonic
   ret void
 }
 
@@ -282,7 +282,7 @@ define void @work_group_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) acquire acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) acquire acquire
   ret void
 }
 
@@ -293,7 +293,7 @@ define void @work_group_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %ol
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) release acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) release acquire
   ret void
 }
 
@@ -304,7 +304,7 @@ define void @work_group_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %ol
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) acq_rel acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) acq_rel acquire
   ret void
 }
 
@@ -315,7 +315,7 @@ define void @work_group_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %ol
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) seq_cst acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) seq_cst acquire
   ret void
 }
 
@@ -326,7 +326,7 @@ define void @work_group_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %ol
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(3) seq_cst seq_cst
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(3) seq_cst seq_cst
   ret void
 }
 
@@ -337,7 +337,7 @@ define void @work_group_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %ol
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) monotonic monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) monotonic monotonic
   ret void
 }
 
@@ -348,7 +348,7 @@ define void @wavefront_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32 
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) acquire monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) acquire monotonic
   ret void
 }
 
@@ -359,7 +359,7 @@ define void @wavefront_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %o
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) release monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) release monotonic
   ret void
 }
 
@@ -370,7 +370,7 @@ define void @wavefront_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %o
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) acq_rel monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) acq_rel monotonic
   ret void
 }
 
@@ -381,7 +381,7 @@ define void @wavefront_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %o
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) seq_cst monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) seq_cst monotonic
   ret void
 }
 
@@ -392,7 +392,7 @@ define void @wavefront_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %o
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) acquire acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) acquire acquire
   ret void
 }
 
@@ -403,7 +403,7 @@ define void @wavefront_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) release acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) release acquire
   ret void
 }
 
@@ -414,7 +414,7 @@ define void @wavefront_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) acq_rel acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) acq_rel acquire
   ret void
 }
 
@@ -425,7 +425,7 @@ define void @wavefront_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) seq_cst acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) seq_cst acquire
   ret void
 }
 
@@ -436,7 +436,7 @@ define void @wavefront_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(4) seq_cst seq_cst
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(4) seq_cst seq_cst
   ret void
 }
 
@@ -447,7 +447,7 @@ define void @wavefront_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %old
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) monotonic monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) monotonic monotonic
   ret void
 }
 
@@ -458,7 +458,7 @@ define void @image_monotonic_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) acquire monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) acquire monotonic
   ret void
 }
 
@@ -469,7 +469,7 @@ define void @image_acquire_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) release monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) release monotonic
   ret void
 }
 
@@ -480,7 +480,7 @@ define void @image_release_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) acq_rel monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) acq_rel monotonic
   ret void
 }
 
@@ -491,7 +491,7 @@ define void @image_acq_rel_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) seq_cst monotonic
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) seq_cst monotonic
   ret void
 }
 
@@ -502,7 +502,7 @@ define void @image_seq_cst_monotonic(i32 addrspace(4)* %out, i32 %in, i32 %old) 
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) acquire acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) acquire acquire
   ret void
 }
 
@@ -513,7 +513,7 @@ define void @image_acquire_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) release acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) release acquire
   ret void
 }
 
@@ -524,7 +524,7 @@ define void @image_release_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) acq_rel acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) acq_rel acquire
   ret void
 }
 
@@ -535,7 +535,7 @@ define void @image_acq_rel_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) seq_cst acquire
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) seq_cst acquire
   ret void
 }
 
@@ -546,7 +546,7 @@ define void @image_seq_cst_acquire(i32 addrspace(4)* %out, i32 %in, i32 %old) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_seq_cst_seq_cst(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(5) seq_cst seq_cst
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(5) seq_cst seq_cst
   ret void
 }
 

--- a/test/CodeGen/AMDGPU/memory-model-atomic-fence.ll
+++ b/test/CodeGen/AMDGPU/memory-model-atomic-fence.ll
@@ -43,7 +43,7 @@ define void @system_seq_cst() {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 ; CHECK-NEXT: s_endpgm
 define void @agent_acquire() {
-  fence synchscope(2) acquire
+  fence syncscope(2) acquire
   ret void
 }
 
@@ -52,7 +52,7 @@ define void @agent_acquire() {
 ; CHECK-NEXT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NEXT: s_endpgm
 define void @agent_release() {
-  fence synchscope(2) release
+  fence syncscope(2) release
   ret void
 }
 
@@ -62,7 +62,7 @@ define void @agent_release() {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 ; CHECK-NEXT: s_endpgm
 define void @agent_acq_rel() {
-  fence synchscope(2) acq_rel
+  fence syncscope(2) acq_rel
   ret void
 }
 
@@ -72,7 +72,7 @@ define void @agent_acq_rel() {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 ; CHECK-NEXT: s_endpgm
 define void @agent_seq_cst() {
-  fence synchscope(2) seq_cst
+  fence syncscope(2) seq_cst
   ret void
 }
 
@@ -80,7 +80,7 @@ define void @agent_seq_cst() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @work_group_acquire() {
-  fence synchscope(3) acquire
+  fence syncscope(3) acquire
   ret void
 }
 
@@ -88,7 +88,7 @@ define void @work_group_acquire() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @work_group_release() {
-  fence synchscope(3) release
+  fence syncscope(3) release
   ret void
 }
 
@@ -96,7 +96,7 @@ define void @work_group_release() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @work_group_acq_rel() {
-  fence synchscope(3) acq_rel
+  fence syncscope(3) acq_rel
   ret void
 }
 
@@ -104,7 +104,7 @@ define void @work_group_acq_rel() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @work_group_seq_cst() {
-  fence synchscope(3) seq_cst
+  fence syncscope(3) seq_cst
   ret void
 }
 
@@ -112,7 +112,7 @@ define void @work_group_seq_cst() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @wavefront_acquire() {
-  fence synchscope(4) acquire
+  fence syncscope(4) acquire
   ret void
 }
 
@@ -120,7 +120,7 @@ define void @wavefront_acquire() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @wavefront_release() {
-  fence synchscope(4) release
+  fence syncscope(4) release
   ret void
 }
 
@@ -128,7 +128,7 @@ define void @wavefront_release() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @wavefront_acq_rel() {
-  fence synchscope(4) acq_rel
+  fence syncscope(4) acq_rel
   ret void
 }
 
@@ -136,7 +136,7 @@ define void @wavefront_acq_rel() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @wavefront_seq_cst() {
-  fence synchscope(4) seq_cst
+  fence syncscope(4) seq_cst
   ret void
 }
 
@@ -144,7 +144,7 @@ define void @wavefront_seq_cst() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @image_acquire() {
-  fence synchscope(5) acquire
+  fence syncscope(5) acquire
   ret void
 }
 
@@ -152,7 +152,7 @@ define void @image_acquire() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @image_release() {
-  fence synchscope(5) release
+  fence syncscope(5) release
   ret void
 }
 
@@ -160,7 +160,7 @@ define void @image_release() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @image_acq_rel() {
-  fence synchscope(5) acq_rel
+  fence syncscope(5) acq_rel
   ret void
 }
 
@@ -168,7 +168,7 @@ define void @image_acq_rel() {
 ; CHECK: BB#0
 ; CHECK-NEXT: s_endpgm
 define void @image_seq_cst() {
-  fence synchscope(5) seq_cst
+  fence syncscope(5) seq_cst
   ret void
 }
 

--- a/test/CodeGen/AMDGPU/memory-model-atomic-load.ll
+++ b/test/CodeGen/AMDGPU/memory-model-atomic-load.ll
@@ -55,7 +55,7 @@ define void @system_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @agent_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(2) unordered, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(2) unordered, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -67,7 +67,7 @@ define void @agent_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @agent_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(2) monotonic, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(2) monotonic, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -79,7 +79,7 @@ define void @agent_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @agent_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(2) acquire, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(2) acquire, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -91,7 +91,7 @@ define void @agent_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NEXT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @agent_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(2) seq_cst, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(2) seq_cst, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -103,7 +103,7 @@ define void @agent_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @work_group_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(3) unordered, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(3) unordered, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -115,7 +115,7 @@ define void @work_group_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out)
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @work_group_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(3) monotonic, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(3) monotonic, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -127,7 +127,7 @@ define void @work_group_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out)
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @work_group_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(3) acquire, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(3) acquire, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -139,7 +139,7 @@ define void @work_group_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @work_group_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(3) seq_cst, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(3) seq_cst, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -151,7 +151,7 @@ define void @work_group_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @wavefront_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(4) unordered, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(4) unordered, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -163,7 +163,7 @@ define void @wavefront_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out) 
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @wavefront_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(4) monotonic, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(4) monotonic, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -175,7 +175,7 @@ define void @wavefront_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out) 
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @wavefront_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(4) acquire, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(4) acquire, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -187,7 +187,7 @@ define void @wavefront_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @wavefront_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(4) seq_cst, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(4) seq_cst, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -199,7 +199,7 @@ define void @wavefront_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @image_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(5) unordered, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(5) unordered, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -211,7 +211,7 @@ define void @image_unordered(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @image_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(5) monotonic, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(5) monotonic, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -223,7 +223,7 @@ define void @image_monotonic(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @image_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(5) acquire, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(5) acquire, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
@@ -235,7 +235,7 @@ define void @image_acquire(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: buffer_wbinvl1_vol
 ; CHECK: flat_store_dword v{{\[[0-9]+:[0-9]+\]}}, [[RET]]
 define void @image_seq_cst(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(5) seq_cst, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(5) seq_cst, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }

--- a/test/CodeGen/AMDGPU/memory-model-atomic-rmw.ll
+++ b/test/CodeGen/AMDGPU/memory-model-atomic-rmw.ll
@@ -56,7 +56,7 @@ define void @system_seq_cst(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @agent_monotonic(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(2) monotonic
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(2) monotonic
   ret void
 }
 
@@ -66,7 +66,7 @@ define void @agent_monotonic(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NEXT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_acquire(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(2) acquire
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(2) acquire
   ret void
 }
 
@@ -76,7 +76,7 @@ define void @agent_acquire(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @agent_release(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(2) release
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(2) release
   ret void
 }
 
@@ -86,7 +86,7 @@ define void @agent_release(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NEXT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_acq_rel(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(2) acq_rel
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(2) acq_rel
   ret void
 }
 
@@ -96,7 +96,7 @@ define void @agent_acq_rel(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NEXT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NEXT: buffer_wbinvl1_vol
 define void @agent_seq_cst(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(2) seq_cst
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(2) seq_cst
   ret void
 }
 
@@ -106,7 +106,7 @@ define void @agent_seq_cst(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_monotonic(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(3) monotonic
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(3) monotonic
   ret void
 }
 
@@ -116,7 +116,7 @@ define void @work_group_monotonic(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_acquire(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(3) acquire
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(3) acquire
   ret void
 }
 
@@ -126,7 +126,7 @@ define void @work_group_acquire(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_release(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(3) release
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(3) release
   ret void
 }
 
@@ -136,7 +136,7 @@ define void @work_group_release(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_acq_rel(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(3) acq_rel
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(3) acq_rel
   ret void
 }
 
@@ -146,7 +146,7 @@ define void @work_group_acq_rel(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @work_group_seq_cst(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(3) seq_cst
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(3) seq_cst
   ret void
 }
 
@@ -156,7 +156,7 @@ define void @work_group_seq_cst(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_monotonic(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(4) monotonic
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(4) monotonic
   ret void
 }
 
@@ -166,7 +166,7 @@ define void @wavefront_monotonic(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_acquire(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(4) acquire
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(4) acquire
   ret void
 }
 
@@ -176,7 +176,7 @@ define void @wavefront_acquire(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_release(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(4) release
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(4) release
   ret void
 }
 
@@ -186,7 +186,7 @@ define void @wavefront_release(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_acq_rel(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(4) acq_rel
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(4) acq_rel
   ret void
 }
 
@@ -196,7 +196,7 @@ define void @wavefront_acq_rel(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @wavefront_seq_cst(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(4) seq_cst
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(4) seq_cst
   ret void
 }
 
@@ -206,7 +206,7 @@ define void @wavefront_seq_cst(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_monotonic(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(5) monotonic
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(5) monotonic
   ret void
 }
 
@@ -216,7 +216,7 @@ define void @image_monotonic(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_acquire(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(5) acquire
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(5) acquire
   ret void
 }
 
@@ -226,7 +226,7 @@ define void @image_acquire(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_release(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(5) release
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(5) release
   ret void
 }
 
@@ -236,7 +236,7 @@ define void @image_release(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_acq_rel(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(5) acq_rel
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(5) acq_rel
   ret void
 }
 
@@ -246,7 +246,7 @@ define void @image_acq_rel(i32 addrspace(4)* %out, i32 %in) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NOT: buffer_wbinvl1_vol
 define void @image_seq_cst(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(5) seq_cst
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(5) seq_cst
   ret void
 }
 

--- a/test/CodeGen/AMDGPU/memory-model-atomic-store.ll
+++ b/test/CodeGen/AMDGPU/memory-model-atomic-store.ll
@@ -36,7 +36,7 @@ define void @system_seq_cst(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @agent_unordered(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(2) unordered, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(2) unordered, align 4
   ret void
 }
 
@@ -44,7 +44,7 @@ define void @agent_unordered(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @agent_monotonic(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(2) monotonic, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(2) monotonic, align 4
   ret void
 }
 
@@ -52,7 +52,7 @@ define void @agent_monotonic(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NEXT: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @agent_release(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(2) release, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(2) release, align 4
   ret void
 }
 
@@ -60,7 +60,7 @@ define void @agent_release(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK: s_waitcnt vmcnt(0){{$}}
 ; CHECK-NEXT: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @agent_seq_cst(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(2) seq_cst, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(2) seq_cst, align 4
   ret void
 }
 
@@ -68,7 +68,7 @@ define void @agent_seq_cst(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @work_group_unordered(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(3) unordered, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(3) unordered, align 4
   ret void
 }
 
@@ -76,7 +76,7 @@ define void @work_group_unordered(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @work_group_monotonic(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(3) monotonic, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(3) monotonic, align 4
   ret void
 }
 
@@ -84,7 +84,7 @@ define void @work_group_monotonic(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @work_group_release(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(3) release, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(3) release, align 4
   ret void
 }
 
@@ -92,7 +92,7 @@ define void @work_group_release(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @work_group_seq_cst(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(3) seq_cst, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(3) seq_cst, align 4
   ret void
 }
 
@@ -100,7 +100,7 @@ define void @work_group_seq_cst(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @wavefront_unordered(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(4) unordered, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(4) unordered, align 4
   ret void
 }
 
@@ -108,7 +108,7 @@ define void @wavefront_unordered(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @wavefront_monotonic(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(4) monotonic, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(4) monotonic, align 4
   ret void
 }
 
@@ -116,7 +116,7 @@ define void @wavefront_monotonic(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @wavefront_release(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(4) release, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(4) release, align 4
   ret void
 }
 
@@ -124,7 +124,7 @@ define void @wavefront_release(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @wavefront_seq_cst(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(4) seq_cst, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(4) seq_cst, align 4
   ret void
 }
 
@@ -132,7 +132,7 @@ define void @wavefront_seq_cst(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @image_unordered(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(5) unordered, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(5) unordered, align 4
   ret void
 }
 
@@ -140,7 +140,7 @@ define void @image_unordered(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @image_monotonic(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(5) monotonic, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(5) monotonic, align 4
   ret void
 }
 
@@ -148,7 +148,7 @@ define void @image_monotonic(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @image_release(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(5) release, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(5) release, align 4
   ret void
 }
 
@@ -156,7 +156,7 @@ define void @image_release(i32 %in, i32 addrspace(4)* %out) {
 ; CHECK-NOT: s_waitcnt vmcnt(0){{$}}
 ; CHECK: flat_store_dword v[{{[0-9]+}}:{{[0-9]+}}], {{v[0-9]+}}{{$}}
 define void @image_seq_cst(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(5) seq_cst, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(5) seq_cst, align 4
   ret void
 }
 

--- a/test/CodeGen/AMDGPU/memory-model-invalid-synch-scope.ll
+++ b/test/CodeGen/AMDGPU/memory-model-invalid-synch-scope.ll
@@ -2,32 +2,32 @@
 
 ; CHECK: error: <unknown>:0:0: in function invalid_fence void (): Unknown synchronization scope
 define void @invalid_fence() {
-  fence synchscope(6) seq_cst
+  fence syncscope(6) seq_cst
   ret void
 }
 
 ; CHECK: error: <unknown>:0:0: in function invalid_load void (i32 addrspace(4)*, i32 addrspace(4)*): Unknown synchronization scope
 define void @invalid_load(i32 addrspace(4)* %in, i32 addrspace(4)* %out) {
-  %val = load atomic i32, i32 addrspace(4)* %in synchscope(6) seq_cst, align 4
+  %val = load atomic i32, i32 addrspace(4)* %in syncscope(6) seq_cst, align 4
   store i32 %val, i32 addrspace(4)* %out
   ret void
 }
 
 ; CHECK: error: <unknown>:0:0: in function invalid_store void (i32, i32 addrspace(4)*): Unknown synchronization scope
 define void @invalid_store(i32 %in, i32 addrspace(4)* %out) {
-  store atomic i32 %in, i32 addrspace(4)* %out synchscope(6) seq_cst, align 4
+  store atomic i32 %in, i32 addrspace(4)* %out syncscope(6) seq_cst, align 4
   ret void
 }
 
 ; CHECK: error: <unknown>:0:0: in function invalid_cmpxchg void (i32 addrspace(4)*, i32, i32): Unknown synchronization scope
 define void @invalid_cmpxchg(i32 addrspace(4)* %out, i32 %in, i32 %old) {
   %gep = getelementptr i32, i32 addrspace(4)* %out, i32 4
-  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in synchscope(6) seq_cst seq_cst
+  %val = cmpxchg volatile i32 addrspace(4)* %gep, i32 %old, i32 %in syncscope(6) seq_cst seq_cst
   ret void
 }
 
 ; CHECK: error: <unknown>:0:0: in function invalid_rmw void (i32 addrspace(4)*, i32): Unknown synchronization scope
 define void @invalid_rmw(i32 addrspace(4)* %out, i32 %in) {
-  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in synchscope(6) seq_cst
+  %val = atomicrmw volatile xchg i32 addrspace(4)* %out, i32 %in syncscope(6) seq_cst
   ret void
 }

--- a/test/CodeGen/AMDGPU/opencl-1.2-atomics.ll
+++ b/test/CodeGen/AMDGPU/opencl-1.2-atomics.ll
@@ -1,9 +1,9 @@
 ; RUN:   opt -mtriple=amdgcn--amdhsa -amdgpu-lower-opencl-atomic-builtins -mcpu=fiji -S < %s | FileCheck %s
-; CHECK: atomicrmw add i32 addrspace(1)* null, i32 1 synchscope(2) monotonic
-; CHECK: atomicrmw add i32 addrspace(1)* null, i32 0 synchscope(2) monotonic
-; CHECK: cmpxchg i32 addrspace(1)* null, i32 0, i32 0 synchscope(2) monotonic monotonic
-; CHECK: atomicrmw xchg i32 addrspace(1)* null, i32 0 synchscope(2) monotonic
-; CHECK: [[A:%[0-9]*]] = atomicrmw xchg i32 addrspace(3)* null, i32 0 synchscope(2) monotonic
+; CHECK: atomicrmw add i32 addrspace(1)* null, i32 1 syncscope(2) monotonic
+; CHECK: atomicrmw add i32 addrspace(1)* null, i32 0 syncscope(2) monotonic
+; CHECK: cmpxchg i32 addrspace(1)* null, i32 0, i32 0 syncscope(2) monotonic monotonic
+; CHECK: atomicrmw xchg i32 addrspace(1)* null, i32 0 syncscope(2) monotonic
+; CHECK: [[A:%[0-9]*]] = atomicrmw xchg i32 addrspace(3)* null, i32 0 syncscope(2) monotonic
 ; CHECK: bitcast i32 [[A]] to float
 
 define amdgpu_kernel void @test() {

--- a/test/CodeGen/AMDGPU/opencl-2.0-atomics.ll
+++ b/test/CodeGen/AMDGPU/opencl-2.0-atomics.ll
@@ -1,10 +1,10 @@
 ; RUN: opt -mtriple=amdgcn--amdhsa -amdgpu-lower-opencl-atomic-builtins -mcpu=fiji -S < %s | FileCheck %s
-; CHECK: cmpxchg i32 addrspace(4)* null, i32 %{{[0-9]+}}, i32 0 synchscope(2) seq_cst seq_cst
-; CHECK: cmpxchg i32 addrspace(4)* null, i32 %{{[0-9]+}}, i32 0 synchscope(4) release acquire
-; CHECK: atomicrmw add i32 addrspace(4)* null, i32 1 synchscope(3) release
+; CHECK: cmpxchg i32 addrspace(4)* null, i32 %{{[0-9]+}}, i32 0 syncscope(2) seq_cst seq_cst
+; CHECK: cmpxchg i32 addrspace(4)* null, i32 %{{[0-9]+}}, i32 0 syncscope(4) release acquire
+; CHECK: atomicrmw add i32 addrspace(4)* null, i32 1 syncscope(3) release
 ; CHECK: store volatile i32 42, i32 addrspace(4)* addrspacecast (i32 addrspace(3)* @test.guide to i32 addrspace(4)*)
-; CHECK: load atomic volatile i32, i32 addrspace(4)* null synchscope(2) monotonic, align 4
-; CHECK: store atomic volatile i32 0, i32 addrspace(4)* null synchscope(2) release, align 4
+; CHECK: load atomic volatile i32, i32 addrspace(4)* null syncscope(2) monotonic, align 4
+; CHECK: store atomic volatile i32 0, i32 addrspace(4)* null syncscope(2) release, align 4
 ; CHECK: call void @my_atomic_compare_exchange_strong_explicit(
 
 @test.guide = internal addrspace(3) global i32 undef, align 4


### PR DESCRIPTION
Summary of changes:
- Keyword for synchronization scope changed: synchscope -> syncscope
- Syncscope argument size changed: 32 bits -> 8 bits
- Minor improvements

Phabricator reviews:
- https://reviews.llvm.org/D21723
- https://reviews.llvm.org/D24577
- https://reviews.llvm.org/D24623
