### PR TITLE
SWDEV-104457 unreachable in conversion test. 

### DIFF
--- a/lib/Target/AMDGPU/AMDGPUOCL12Adapter.cpp
+++ b/lib/Target/AMDGPU/AMDGPUOCL12Adapter.cpp
@@ -195,7 +195,7 @@ void createOCL20BuiltinFuncDefn(Function *OldFunc, Function *NewFunc) {
     return;
   }
   BBBuilder.CreateRet(CallInstVal);
-  OldFunc->setLinkage(GlobalValue::ExternalWeakLinkage);
+  OldFunc->setLinkage(GlobalValue::LinkOnceODRLinkage);
   return;
 }
 


### PR DESCRIPTION
OCL 1.2 builtin wrapper linkage changed from external_weak to linkonce_odr
