### PR TITLE
Disable OCL12Adapter pass if no opencl.ocl.version metadata present

### DIFF
--- a/lib/Target/AMDGPU/AMDGPUOCL12Adapter.cpp
+++ b/lib/Target/AMDGPU/AMDGPUOCL12Adapter.cpp
@@ -230,5 +230,9 @@ static bool findAndDefineBuiltinCalls(Module &M) {
 }
 
 bool AMDGPUOCL12Adapter::runOnModule(Module &M) {
+  NamedMDNode *OCLVersion = M.getNamedMetadata("opencl.ocl.version");
+  if (!OCLVersion) {
+    return false;
+  }
   return findAndDefineBuiltinCalls(M);
 }


### PR DESCRIPTION
OCL12 adapter has no use inside HCC but sometimes misinterprets functions as OCL builtins. Disable it if no opencl.ocl.version metadata is present.