### PR TITLE
Fix infinite loop in instcombine due to optimize alloca.

### DIFF
--- a/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -2245,8 +2245,6 @@ SDValue SITargetLowering::lowerADDRSPACECAST(SDValue Op,
   }
 
   // global <-> flat are no-ops and never emitted.
-  DEBUG(dbgs() << "Invalid addrspacecast:\n";
-        ASC->dump());
 
   DiagnosticInfoUnsupported InvalidAddrSpaceCast(
     *MF.getFunction(), "invalid addrspacecast", SL.getDebugLoc());


### PR DESCRIPTION
This reverts commit f9fd62dd2c19db1cefa958f35e187c63fadae5a8 and commit the
up-to-date patch in https://reviews.llvm.org/D27283, which fixes this issue
and contains test for this issue.

When there is an alloca which is initialized by a constant global array and
it is later passed to a function as argument, the alloca cannot be replaced
by the constant global array. In this case, the alloca should not be added
to the work list. The original commit did that, which caused infinite loop
in instcombine. This updated patch does not add it to work list in this
case.

Change-Id: Ic40b85d48e46031c1e63f55405fcc8b853f96000