### PR TITLE
teach kernel node visitor to ignore kernel metadata nodes with NULL

### DIFF
--- a/lib/Transforms/EraseNonkernel/EraseNonkernel.cpp
+++ b/lib/Transforms/EraseNonkernel/EraseNonkernel.cpp
@@ -62,6 +62,7 @@ KernelNodeVisitor::KernelNodeVisitor(FunctionVect& FV)
 void KernelNodeVisitor::operator()(MDNode *N)
 {
         if ( N->getNumOperands() < 1) return;
+        if ( N->getOperand(0) == nullptr) return;
         const MDOperand& Op = N->getOperand(0);
         if ( Function * F = mdconst::dyn_extract<Function>(Op)) {
                 found_kernels.push_back(F);

--- a/lib/Transforms/Promote/Promote.cpp
+++ b/lib/Transforms/Promote/Promote.cpp
@@ -1707,6 +1707,7 @@ KernelNodeVisitor::KernelNodeVisitor(FunctionVect& FV)
 void KernelNodeVisitor::operator()(MDNode *N)
 {
   if ( N->getNumOperands() < 1) return;
+  if ( N->getOperand(0) == nullptr) return;
   const MDOperand& Op = N->getOperand(0);
   if ( Function * F = mdconst::dyn_extract<Function>(Op)) {
     found_kernels.push_back(F);


### PR DESCRIPTION
Encountered the following metadata produced by bugpoint:

!hcc.kernels = !{!0}

!0 = distinct !{null}

which would cause EraseNonkernel and Promote to crash.  
Teach them to ignore this kind of metadata to avoid mis-guiding bugpoint


