### PR TITLE
Fix relative include path in amdgpu-objdump

### DIFF
--- a/tools/amdgpu-objdump/CMakeLists.txt
+++ b/tools/amdgpu-objdump/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories( ${CMAKE_SOURCE_DIR}/lib/Target/AMDGPU/ )
+include_directories( ${PROJECT_SOURCE_DIR}/lib/Target/AMDGPU/ )
 
 set(LLVM_LINK_COMPONENTS
   AllTargetsAsmPrinters


### PR DESCRIPTION
This is required to fix the hcc build when properly
adding llvm as a sub project build.