### PR TITLE
AMDGPU/SI: clpVectorExpansion needs Linker and Demangling symbols

### DIFF
--- a/lib/Target/AMDGPU/LLVMBuild.txt
+++ b/lib/Target/AMDGPU/LLVMBuild.txt
@@ -30,5 +30,5 @@ has_disassembler = 1
 type = Library
 name = AMDGPUCodeGen
 parent = AMDGPU
-required_libraries = Analysis AsmPrinter CodeGen Core IPO MC AMDGPUAsmPrinter AMDGPUDesc AMDGPUInfo AMDGPUUtils Scalar SelectionDAG Support Target TransformUtils Vectorize GlobalISel
+required_libraries = Analysis AsmPrinter CodeGen Core Demangle IPO MC AMDGPUAsmPrinter AMDGPUDesc AMDGPUInfo AMDGPUUtils Linker Scalar SelectionDAG Support Target TransformUtils Vectorize GlobalISel
 add_to_library_groups = AMDGPU


### PR DESCRIPTION
Fixes  BUILD_SHARED_LIBS build errors:
```
CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUConvertAtomicLibCalls.cpp.o: In function `llvm::AMDGPUConvertAtomicLibCalls::lowerAtomic(llvm::CallSite const&)':
/home/vesely/llvm-hcc/lib/Target/AMDGPU/AMDGPUConvertAtomicLibCalls.cpp:246: undefined reference to `llvm::itaniumDemangle(char const*, char*, unsigned long*, int*)'
CMakeFiles/LLVMAMDGPUCodeGen.dir/AMDGPUclpVectorExpansion.cpp.o: In function `(anonymous namespace)::AMDGPUclpVectorExpansion::runOnModule(llvm::Module&)':
/home/vesely/llvm-hcc/lib/Target/AMDGPU/AMDGPUclpVectorExpansion.cpp:1061: undefined reference to `llvm::Linker::linkModules(llvm::Module&, std::unique_ptr<llvm::Module, std::default_delete<llvm::Module> >, unsigned int, std::function<void (llvm::Module&, llvm::StringSet<llvm::MallocAllocator> const&)>)'
```