### PR TITLE
EraseNonKernel: Do not erase functions called by kernel

### DIFF
--- a/lib/Transforms/EraseNonkernel/EraseNonkernel.cpp
+++ b/lib/Transforms/EraseNonkernel/EraseNonkernel.cpp
@@ -11,8 +11,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-//#define DEBUG_TYPE "PromoteGlobals"
+#define DEBUG_TYPE "EraseNonKernel"
 
+#include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/Analysis/CallGraph.h"
 #include "llvm/IR/Verifier.h"
@@ -28,9 +29,11 @@ using namespace llvm;
 
 namespace {
 
-/* Data type container into which the list of LLVM functions
-   that are OpenCL kernels will be stored */
-typedef SmallVector<Function *, 3> FunctionVect;
+/* If a function maps to true, it is either a kernel or called by a kernel.
+ * If a function maps to false, it is neither a kernel nor called by a kernel.
+ * Otherwise it is unknown whether it is a kernel or called by a kernel.
+ */
+typedef DenseMap<Function *, bool> FunctionMap;
 
 /* The name of the MDNode into which the list of
    MD nodes referencing each HCC kernel is stored. */
@@ -48,15 +51,15 @@ NamedMDNode * getKernelListMDNode (Module & M)
    located into another MDNode */
 class KernelNodeVisitor {
         public:
-        KernelNodeVisitor(FunctionVect& FV);
+        KernelNodeVisitor(FunctionMap& FV);
         void operator()(MDNode * N);
 
         private:
-        FunctionVect& found_kernels;
+        FunctionMap& FuncCalledByKernel;
 };
 
-KernelNodeVisitor::KernelNodeVisitor(FunctionVect& FV)
-        : found_kernels(FV)
+KernelNodeVisitor::KernelNodeVisitor(FunctionMap& FV)
+        : FuncCalledByKernel(FV)
 {}
 
 void KernelNodeVisitor::operator()(MDNode *N)
@@ -65,7 +68,7 @@ void KernelNodeVisitor::operator()(MDNode *N)
         if ( N->getOperand(0) == nullptr) return;
         const MDOperand& Op = N->getOperand(0);
         if ( Function * F = mdconst::dyn_extract<Function>(Op)) {
-                found_kernels.push_back(F);
+                FuncCalledByKernel[F] = true;
         }
 }
 
@@ -81,7 +84,7 @@ void visitMDNodeOperands(NamedMDNode * N, KernelNodeVisitor& visitor)
 /* Accumulate LLVM functions that are kernels within the
    found_kernels vector. Return true if kernels are found.
    False otherwise. */
-bool findKernels(Module& M, FunctionVect& found_kernels)
+bool findKernels(Module& M, FunctionMap& found_kernels)
 {
         NamedMDNode * root = getKernelListMDNode(M);
         if (!root || (root->getNumOperands() == 0)) return false;
@@ -93,7 +96,7 @@ bool findKernels(Module& M, FunctionVect& found_kernels)
 }
 
 class EraseNonkernels : public ModulePass {
-        FunctionVect foundKernels;
+        FunctionMap FuncCalledByKernel;
         public:
         static char ID;
         EraseNonkernels();
@@ -114,30 +117,32 @@ void EraseNonkernels::getAnalysisUsage(AnalysisUsage& AU) const
         AU.addRequired<CallGraphWrapperPass>();
 }
 
+static bool IsCalledByKernel(Function *F, FunctionMap &FuncCalledByKernel) {
+  auto Loc = FuncCalledByKernel.find(F);
+  if (Loc != FuncCalledByKernel.end())
+    return FuncCalledByKernel[F];
+  for (auto I:F->users()) {
+    CallSite CS(I);
+    if (CS && IsCalledByKernel(CS.getCaller(), FuncCalledByKernel)) {
+      FuncCalledByKernel[F] = true;
+      return true;
+    }
+  }
+  FuncCalledByKernel[F] = false;
+  return false;
+}
+
 bool EraseNonkernels::runOnModule(Module &M)
 {
-    findKernels(M, foundKernels);
+    findKernels(M, FuncCalledByKernel);
 
     typedef Module::iterator func_iterator;
     for (func_iterator F = M.begin(), Fend = M.end();
             F != Fend; ++F) {
-        typedef FunctionVect::const_iterator kernel_iterator;
-        bool isKernel = false;
-        if (!foundKernels.empty()) {
-            for (kernel_iterator KernFunc = foundKernels.begin(), KernFuncEnd = foundKernels.end();
-                    KernFunc != KernFuncEnd; ++KernFunc) {
-                if (*KernFunc == &*F) {
-                    isKernel = true;
-                }
-            }
-        }
-
-        if (isKernel) continue;
-
+        if (IsCalledByKernel(&*F, FuncCalledByKernel)) continue;
         F->deleteBody();
     }
 
-    foundKernels.clear();
     // Some global variables may be dead after removing dead kernels
     Module::GlobalListType &globals = M.getGlobalList();
     for (Module::global_iterator I = globals.begin(), E = globals.end();
@@ -161,43 +166,14 @@ bool EraseNonkernels::runOnModule(Module &M)
 	Module::FunctionListType &global_funcs = M.getFunctionList();
 	for (Module::iterator I = global_funcs.begin(), E = global_funcs.end(); I != E; ) {
 		// keep functions with AMDGPU_KERNEL linkage
-		if (I->getCallingConv() == CallingConv::AMDGPU_KERNEL) {
-			I++;
-			continue;
-		}
-
-		// keep certain intrinsics
-		// FIXME: switch to attribute-based check
-		if (I->getName().find("get_global_size") != StringRef::npos ||
-                        I->getName().find("get_global_id") != StringRef::npos ||
-                        I->getName().find("get_local_size") != StringRef::npos ||
-                        I->getName().find("get_local_id") != StringRef::npos ||
-                        I->getName().find("get_num_groups") != StringRef::npos ||
-                        I->getName().find("get_group_id") != StringRef::npos ||
-                        I->getName().find("barrier") != StringRef::npos ||
-                        I->getName().find("opencl_") != StringRef::npos ||
-                        I->getName().find("atomic_") != StringRef::npos ||
-                        I->getName().find("llvm.") != StringRef::npos || 
-                        I->getName().find("__") == 0 ||
-                        I->getName().find("amdgcn_") == 0 ||
-                        I->getName().find("hc_get_grid_size") != StringRef::npos || 
-                        I->getName().find("hc_get_workitem_absolute_id") != StringRef::npos ||
-                        I->getName().find("hc_get_workitem_id") != StringRef::npos ||
-                        I->getName().find("hc_get_group_size") != StringRef::npos ||
-                        I->getName().find("hc_get_num_groups") != StringRef::npos ||
-                        I->getName().find("hc_get_group_id") != StringRef::npos ||
-                        I->getName().find("hc_barrier") != StringRef::npos ||
-                        I->getName().find("get_group_segment_size") != StringRef::npos || 
-                        I->getName().find("get_static_group_segment_size") != StringRef::npos || 
-                        I->getName().find("get_group_segment_base_pointer") != StringRef::npos || 
-                        I->getName().find("get_dynamic_group_segment_base_pointer") != StringRef::npos ||
-                        I->getName().find("experimental8parallel") != StringRef::npos) {
+		if (I->getCallingConv() == CallingConv::AMDGPU_KERNEL ||
+		    IsCalledByKernel(&*I, FuncCalledByKernel)) {
 			I++;
 			continue;
 		}
 
 		// remove all other functions
-		//llvm::errs() << "[REMOVE FUNC]: " << I->getName() << "\n";
+		DEBUG(llvm::dbgs() << "[REMOVE FUNC]: " << I->getName() << "\n");
 		I->removeFromParent();
 		I = global_funcs.begin();
 	}
@@ -207,7 +183,7 @@ bool EraseNonkernels::runOnModule(Module &M)
 	for (Module::alias_iterator I = global_aliases.begin(), E = global_aliases.end(); I != E; ) {
 		I->removeDeadConstantUsers();
 		if (I->getNumUses() == 0) {
-			//llvm::errs() << "[REMOVE ALIAS]: " << I->getName() << "\n";
+			DEBUG(llvm::dbgs() << "[REMOVE ALIAS]: " << I->getName() << "\n");
 			I->eraseFromParent();
 			I = global_aliases.begin();
 		} else {


### PR DESCRIPTION
This fixes the IR verfier error about referring a function in another
module due to function called by kernel being erased.

This makes the IR cleaner and partially fixes hcc unit test HC/auto_annotate_attribute.cpp