### PR TITLE
fix assertion on the number of bits for the offset

### DIFF
--- a/lib/IR/Operator.cpp
+++ b/lib/IR/Operator.cpp
@@ -34,9 +34,9 @@ Type *GEPOperator::getResultElementType() const {
 
 bool GEPOperator::accumulateConstantOffset(const DataLayout &DL,
                                            APInt &Offset) const {
-  assert(Offset.getBitWidth() ==
+  assert(Offset.getBitWidth() <=
              DL.getPointerSizeInBits(getPointerAddressSpace()) &&
-         "The offset must have exactly as many bits as our pointer.");
+         "The offset must have as many or less bits as our pointer.");
 
   for (gep_type_iterator GTI = gep_type_begin(this), GTE = gep_type_end(this);
        GTI != GTE; ++GTI) {


### PR DESCRIPTION
The assert becomes an issue when the Offset was computed from an alloca instruction (address space 5), which is 32-bit, but the GEP instruction has an address expression in generic address (address space casted from an alloca), which is in 64-bit. 