### PR TITLE
HCC ThinLTO initial changes to Function Import

### DIFF
--- a/include/llvm/Transforms/Utils/FunctionImportUtils.h
+++ b/include/llvm/Transforms/Utils/FunctionImportUtils.h
@@ -21,6 +21,9 @@
 namespace llvm {
 class Module;
 
+// Set to true depending on option -force-weak-import
+extern bool ForceWeakImportFlag;
+
 /// Class to handle necessary GlobalValue changes required by ThinLTO
 /// function importing, including linkage changes and any necessary renaming.
 class FunctionImportGlobalProcessing {

--- a/include/llvm/Transforms/Utils/FunctionImportUtils.h
+++ b/include/llvm/Transforms/Utils/FunctionImportUtils.h
@@ -21,8 +21,8 @@
 namespace llvm {
 class Module;
 
-// Set to true depending on option -force-weak-import
-extern bool ForceWeakImportFlag;
+// Set to true depending on option -force-import-weak
+extern bool ForceImportWeakFlag;
 
 /// Class to handle necessary GlobalValue changes required by ThinLTO
 /// function importing, including linkage changes and any necessary renaming.

--- a/lib/Transforms/IPO/FunctionImport.cpp
+++ b/lib/Transforms/IPO/FunctionImport.cpp
@@ -102,11 +102,11 @@ static cl::opt<bool> PrintImports("print-imports", cl::init(false), cl::Hidden,
 static cl::opt<bool> ComputeDead("compute-dead", cl::init(true), cl::Hidden,
                                  cl::desc("Compute dead symbols"));
 
-bool llvm::ForceImportWeakFlag = false;
+bool llvm::ForceImportWeakFlag;
 static cl::opt<bool, true>
 ForceImportWeak("force-import-weak", cl::Hidden,
                 cl::desc("Allow weak functions to be imported"),
-                cl::location(ForceImportWeakFlag));
+                cl::location(ForceImportWeakFlag), cl::init(false));
 
 static cl::opt<bool> EnableImportMetadata(
     "enable-import-metadata", cl::init(

--- a/lib/Transforms/IPO/FunctionImport.cpp
+++ b/lib/Transforms/IPO/FunctionImport.cpp
@@ -102,11 +102,11 @@ static cl::opt<bool> PrintImports("print-imports", cl::init(false), cl::Hidden,
 static cl::opt<bool> ComputeDead("compute-dead", cl::init(true), cl::Hidden,
                                  cl::desc("Compute dead symbols"));
 
-bool llvm::ForceWeakImportFlag = false;
+bool llvm::ForceImportWeakFlag = false;
 static cl::opt<bool, true>
-ForceWeakImport("force-weak-import", cl::Hidden,
+ForceImportWeak("force-import-weak", cl::Hidden,
                 cl::desc("Allow weak functions to be imported"),
-                cl::location(ForceWeakImportFlag));
+                cl::location(ForceImportWeakFlag));
 
 static cl::opt<bool> EnableImportMetadata(
     "enable-import-metadata", cl::init(
@@ -175,7 +175,7 @@ selectCallee(const ModuleSummaryIndex &Index,
         // filtered out.
         if (GVSummary->getSummaryKind() == GlobalValueSummary::GlobalVarKind)
           return false;
-        if (!ForceWeakImportFlag && GlobalValue::isInterposableLinkage(GVSummary->linkage()))
+        if (!ForceImportWeakFlag && GlobalValue::isInterposableLinkage(GVSummary->linkage()))
           // There is no point in importing these, we can't inline them
           return false;
         if (isa<AliasSummary>(GVSummary))

--- a/lib/Transforms/IPO/FunctionImport.cpp
+++ b/lib/Transforms/IPO/FunctionImport.cpp
@@ -169,9 +169,10 @@ selectCallee(const ModuleSummaryIndex &Index,
         // filtered out.
         if (GVSummary->getSummaryKind() == GlobalValueSummary::GlobalVarKind)
           return false;
-        if (GlobalValue::isInterposableLinkage(GVSummary->linkage()))
+        // Do not check for HCC ThinLTO's Cross-module Importing
+        //if (GlobalValue::isInterposableLinkage(GVSummary->linkage()))
           // There is no point in importing these, we can't inline them
-          return false;
+          //return false;
         if (isa<AliasSummary>(GVSummary))
           // Aliases can't point to "available_externally".
           // FIXME: we should import alias as available_externally *function*,

--- a/lib/Transforms/Utils/FunctionImportUtils.cpp
+++ b/lib/Transforms/Utils/FunctionImportUtils.cpp
@@ -151,7 +151,7 @@ FunctionImportGlobalProcessing::getLinkage(const GlobalValue *SGV,
     // program semantics, since the linker will pick the first weak_any
     // definition and importing would change the order they are seen by the
     // linker. The module linking caller needs to enforce this.
-    if(!ForceWeakImportFlag)
+    if(!ForceImportWeakFlag)
       assert(!doImportAsDefinition(SGV));
     // If imported as a declaration, it becomes external_weak.
     return SGV->getLinkage();

--- a/lib/Transforms/Utils/FunctionImportUtils.cpp
+++ b/lib/Transforms/Utils/FunctionImportUtils.cpp
@@ -151,8 +151,8 @@ FunctionImportGlobalProcessing::getLinkage(const GlobalValue *SGV,
     // program semantics, since the linker will pick the first weak_any
     // definition and importing would change the order they are seen by the
     // linker. The module linking caller needs to enforce this.
-    // Don't perform assert for HCC's ThinLTO Cross-module Importing
-    // assert(!doImportAsDefinition(SGV));
+    if(!ForceWeakImportFlag)
+      assert(!doImportAsDefinition(SGV));
     // If imported as a declaration, it becomes external_weak.
     return SGV->getLinkage();
 

--- a/lib/Transforms/Utils/FunctionImportUtils.cpp
+++ b/lib/Transforms/Utils/FunctionImportUtils.cpp
@@ -151,7 +151,8 @@ FunctionImportGlobalProcessing::getLinkage(const GlobalValue *SGV,
     // program semantics, since the linker will pick the first weak_any
     // definition and importing would change the order they are seen by the
     // linker. The module linking caller needs to enforce this.
-    assert(!doImportAsDefinition(SGV));
+    // Don't perform assert for HCC's ThinLTO Cross-module Importing
+    // assert(!doImportAsDefinition(SGV));
     // If imported as a declaration, it becomes external_weak.
     return SGV->getLinkage();
 


### PR DESCRIPTION
This allows Cross-module function importing to occur even for Weak Linkages.