### PR TITLE
[MIOpen] Workaround large non-GlobalValue names

### DIFF
--- a/lib/IR/Value.cpp
+++ b/lib/IR/Value.cpp
@@ -40,7 +40,7 @@
 using namespace llvm;
 
 static cl::opt<unsigned> NonGlobalValueMaxNameSize(
-    "non-global-value-max-name-size", cl::Hidden, cl::init(1024),
+    "non-global-value-max-name-size", cl::Hidden, cl::init(8192),
     cl::desc("Maximum size for the name of non-global values."));
 
 //===----------------------------------------------------------------------===//


### PR DESCRIPTION
This is a workaround for an MIOpen build issue. Seems that LLParser will truncate names that are larger than NonGlobalValueMaxNameSize, therefore multiple names may conflict due to multiple definitions of local value is not allowed.

The root issue is that recently LLVM upstream has a patch to set name size limit (<1024) on non-GlobalValue names. Therefore, for some of the MIOpen kernels, optimizations created variable names that are more than 1024 characters long which gets truncated into 1024 characters. The link-time passes will then complain in the Parser that there are multiple definitions of the same local value name, since many names share similar prefix before truncated.