### PR TITLE
resolve issue in unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp

### DIFF
--- a/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
+++ b/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp
@@ -63,38 +63,28 @@ TEST(LegalizerInfoTest, ScalarRISC) {
   for (unsigned opcode : {G_ADD, G_SUB}) {
     // Check we infer the correct types and actually do what we're told.
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(8)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                                LLT::scalar(32)));
+              LegalizeActionStep(WidenScalar, 0, LLT::scalar(32)));
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(16)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                                LLT::scalar(32)));
-    ASSERT_EQ(
-        L.getAction({opcode, {LLT::scalar(32)}}),
-        LegalizerInfo::LegalizeActionStep(LegalizerInfo::Legal, 0, LLT{}));
-    ASSERT_EQ(
-        L.getAction({opcode, {LLT::scalar(64)}}),
-        LegalizerInfo::LegalizeActionStep(LegalizerInfo::Legal, 0, LLT{}));
+              LegalizeActionStep(WidenScalar, 0, LLT::scalar(32)));
+    ASSERT_EQ(L.getAction({opcode, {LLT::scalar(32)}}),
+              LegalizeActionStep(Legal, 0, LLT{}));
+    ASSERT_EQ(L.getAction({opcode, {LLT::scalar(64)}}),
+              LegalizeActionStep(Legal, 0, LLT{}));
 
     // Make sure the default for over-sized types applies.
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(128)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::NarrowScalar, 0,
-                                                LLT::scalar(64)));
+              LegalizeActionStep(NarrowScalar, 0, LLT::scalar(64)));
     // Make sure we also handle unusual sizes
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(1)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                                LLT::scalar(32)));
+              LegalizeActionStep(WidenScalar, 0, LLT::scalar(32)));
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(31)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                                LLT::scalar(32)));
+              LegalizeActionStep(WidenScalar, 0, LLT::scalar(32)));
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(33)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                                LLT::scalar(64)));
+              LegalizeActionStep(WidenScalar, 0, LLT::scalar(64)));
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(63)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                                LLT::scalar(64)));
+              LegalizeActionStep(WidenScalar, 0, LLT::scalar(64)));
     ASSERT_EQ(L.getAction({opcode, {LLT::scalar(65)}}),
-              LegalizerInfo::LegalizeActionStep(LegalizerInfo::NarrowScalar, 0,
-                                                LLT::scalar(64)));
+              LegalizeActionStep(NarrowScalar, 0, LLT::scalar(64)));
   }
 }
 
@@ -119,23 +109,18 @@ TEST(LegalizerInfoTest, VectorRISC) {
   // Check we infer the correct types and actually do what we're told for some
   // simple cases.
   ASSERT_EQ(L.getAction({G_ADD, {LLT::vector(8, 8)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::Legal, 0, LLT{}));
+            LegalizeActionStep(Legal, 0, LLT{}));
   ASSERT_EQ(L.getAction({G_ADD, {LLT::vector(8, 7)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::vector(8, 8)));
+            LegalizeActionStep(WidenScalar, 0, LLT::vector(8, 8)));
   ASSERT_EQ(L.getAction({G_ADD, {LLT::vector(2, 8)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::MoreElements, 0,
-                                              LLT::vector(8, 8)));
+            LegalizeActionStep(MoreElements, 0, LLT::vector(8, 8)));
   ASSERT_EQ(L.getAction({G_ADD, {LLT::vector(8, 32)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::FewerElements, 0,
-                                              LLT::vector(4, 32)));
+            LegalizeActionStep(FewerElements, 0, LLT::vector(4, 32)));
   // Check a few non-power-of-2 sizes:
   ASSERT_EQ(L.getAction({G_ADD, {LLT::vector(3, 3)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::vector(3, 8)));
+            LegalizeActionStep(WidenScalar, 0, LLT::vector(3, 8)));
   ASSERT_EQ(L.getAction({G_ADD, {LLT::vector(3, 8)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::MoreElements, 0,
-                                              LLT::vector(8, 8)));
+            LegalizeActionStep(MoreElements, 0, LLT::vector(8, 8)));
 }
 
 TEST(LegalizerInfoTest, MultipleTypes) {
@@ -155,15 +140,15 @@ TEST(LegalizerInfoTest, MultipleTypes) {
 
   // Check we infer the correct types and actually do what we're told.
   ASSERT_EQ(L.getAction({G_PTRTOINT, {s64, p0}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::Legal, 0, LLT{}));
+            LegalizeActionStep(Legal, 0, LLT{}));
 
   // Make sure we also handle unusual sizes
   ASSERT_EQ(
       L.getAction({G_PTRTOINT, {LLT::scalar(65), s64}}),
-      LegalizerInfo::LegalizeActionStep(LegalizerInfo::NarrowScalar, 0, s64));
-  ASSERT_EQ(L.getAction({G_PTRTOINT, {s64, LLT::pointer(0, 32)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::Unsupported, 1,
-                                              LLT::pointer(0, 32)));
+      LegalizeActionStep(NarrowScalar, 0, s64));
+  ASSERT_EQ(
+      L.getAction({G_PTRTOINT, {s64, LLT::pointer(0, 32)}}),
+      LegalizeActionStep(Unsupported, 1, LLT::pointer(0, 32)));
 }
 
 TEST(LegalizerInfoTest, MultipleSteps) {
@@ -180,11 +165,9 @@ TEST(LegalizerInfoTest, MultipleSteps) {
   L.computeTables();
 
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(16)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::scalar(32)));
+            LegalizeActionStep(WidenScalar, 0, LLT::scalar(32)));
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(32)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::Lower, 0,
-                                              LLT::scalar(32)));
+            LegalizeActionStep(Lower, 0, LLT::scalar(32)));
 }
 
 TEST(LegalizerInfoTest, SizeChangeStrategy) {
@@ -199,27 +182,20 @@ TEST(LegalizerInfoTest, SizeChangeStrategy) {
 
   // Check we infer the correct types and actually do what we're told.
   for (unsigned Size : {1, 8, 16, 32}) {
-    ASSERT_EQ(
-        L.getAction({G_UREM, {LLT::scalar(Size)}}),
-        LegalizerInfo::LegalizeActionStep(LegalizerInfo::Legal, 0, LLT{}));
+    ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(Size)}}),
+              LegalizeActionStep(Legal, 0, LLT{}));
   }
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(2)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::scalar(8)));
+            LegalizeActionStep(WidenScalar, 0, LLT::scalar(8)));
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(7)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::scalar(8)));
+            LegalizeActionStep(WidenScalar, 0, LLT::scalar(8)));
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(9)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::scalar(16)));
+            LegalizeActionStep(WidenScalar, 0, LLT::scalar(16)));
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(17)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::scalar(32)));
+            LegalizeActionStep(WidenScalar, 0, LLT::scalar(32)));
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(31)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::WidenScalar, 0,
-                                              LLT::scalar(32)));
+            LegalizeActionStep(WidenScalar, 0, LLT::scalar(32)));
   ASSERT_EQ(L.getAction({G_UREM, {LLT::scalar(33)}}),
-            LegalizerInfo::LegalizeActionStep(LegalizerInfo::Unsupported, 0,
-                                              LLT::scalar(33)));
+            LegalizeActionStep(Unsupported, 0, LLT::scalar(33)));
 }
 }


### PR DESCRIPTION
Building the OpenCL tests results in the following error, when the amd-hcc branch is used:

/home/jenkins/workspace/lightning-weekly-build-opencl-github/opencl/compiler/llvm/unittests/CodeGen/GlobalISel/LegalizerInfoTest.cpp:65:389: error: 'LegalizeActionStep' is not a member of 'llvm::LegalizerInfo'

The following PR resolves this error.