### PR TITLE
Remove non-temporal flag for kernargs

### DIFF
--- a/lib/Target/AMDGPU/SIISelLowering.cpp
+++ b/lib/Target/AMDGPU/SIISelLowering.cpp
@@ -1201,7 +1201,6 @@ SDValue SITargetLowering::lowerKernargMemParameter(
 
   SDValue Ptr = lowerKernArgParameterPtr(DAG, SL, Chain, Offset);
   SDValue Load = DAG.getLoad(MemVT, SL, Chain, Ptr, PtrInfo, Align,
-                             MachineMemOperand::MONonTemporal |
                              MachineMemOperand::MODereferenceable |
                              MachineMemOperand::MOInvariant);
 


### PR DESCRIPTION
This help removes SLC / GLC bits when loading from sub-dword kernel arguments, which is very important for performance.