### PR TITLE
LLVM lit test clean up

### DIFF
--- a/utils/lit/lit/TestRunner.py
+++ b/utils/lit/lit/TestRunner.py
@@ -1069,8 +1069,8 @@ def executeScript(test, litConfig, tmpBase, commands, cwd):
         f.write('@echo off\n')
         f.write('\nif %ERRORLEVEL% NEQ 0 EXIT\n'.join(commands))
     else:
-        #if test.config.pipefail:
-        #    f.write('set -o pipefail;')
+        if test.config.pipefail:
+            f.write('set -o pipefail;')
         if litConfig.echo_all_commands:
             f.write('set -x;')
         f.write('{ ' + '; } &&\n{ '.join(commands) + '; }')


### PR DESCRIPTION
There is one remaining LLVM lit test that was failing.  This PR, which just has a change from upstream amd-common, resolves the last LLVM lit failing test for HCC.