### PR TITLE
Remove weird leftover and no longer leak temporary.

### DIFF
--- a/include/llvm/ADT/Triple.h
+++ b/include/llvm/ADT/Triple.h
@@ -206,8 +206,7 @@ public:
     Cygnus,
     CoreCLR,
     Simulator,  // Simulator variants of other systems, e.g., Apple's iOS
-    HCC,
-    LastEnvironmentType = HCC
+    LastEnvironmentType = Simulator
   };
   enum ObjectFormatType {
     UnknownObjectFormat,

--- a/lib/Support/Triple.cpp
+++ b/lib/Support/Triple.cpp
@@ -235,7 +235,6 @@ StringRef Triple::getEnvironmentTypeName(EnvironmentType Kind) {
   case Cygnus: return "cygnus";
   case CoreCLR: return "coreclr";
   case Simulator: return "simulator";
-  case HCC: return "hcc";
    }
 
   llvm_unreachable("Invalid EnvironmentType!");
@@ -526,7 +525,7 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
     .StartsWith("cygnus", Triple::Cygnus)
     .StartsWith("coreclr", Triple::CoreCLR)
     .StartsWith("simulator", Triple::Simulator)
-    .StartsWith("hcc", Triple::HCC)
+    //.StartsWith("hcc", Triple::HCC)
     .Default(Triple::UnknownEnvironment);
 }
 

--- a/lib/Support/Triple.cpp
+++ b/lib/Support/Triple.cpp
@@ -525,7 +525,6 @@ static Triple::EnvironmentType parseEnvironment(StringRef EnvironmentName) {
     .StartsWith("cygnus", Triple::Cygnus)
     .StartsWith("coreclr", Triple::CoreCLR)
     .StartsWith("simulator", Triple::Simulator)
-    //.StartsWith("hcc", Triple::HCC)
     .Default(Triple::UnknownEnvironment);
 }
 

--- a/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -335,8 +335,7 @@ StringRef AMDGPUTargetMachine::getFeatureString(const Function &F) const {
 }
 
 void AMDGPUTargetMachine::addPreLinkPasses(PassManagerBase & PM) {
-  if (getTargetTriple().getEnvironment() != Triple::HCC)
-    PM.add(llvm::createAMDGPUOCL12AdapterPass());
+  PM.add(llvm::createAMDGPUOCL12AdapterPass());
   PM.add(llvm::createAMDGPUPrintfRuntimeBinding());
 }
 

--- a/lib/Transforms/HC/PromotePointerKernArgsToGlobal/PromotePointerKernArgsToGlobal.cpp
+++ b/lib/Transforms/HC/PromotePointerKernArgsToGlobal/PromotePointerKernArgsToGlobal.cpp
@@ -57,8 +57,8 @@ public:
         Builder.SetInsertPoint(&F.getEntryBlock().front());
 
         for_each(PtrArgs.begin(), PtrArgs.end(), [](Argument *PArg) {
-            auto Tmp{new Argument{PArg->getType(), PArg->getName()}};
-            PArg->replaceAllUsesWith(Tmp);
+            Argument Tmp{PArg->getType(), PArg->getName()};
+            PArg->replaceAllUsesWith(&Tmp);
 
             Value *FToG = Builder.CreateAddrSpaceCast(
                 PArg,
@@ -66,7 +66,7 @@ public:
                     ->getElementType()->getPointerTo(GlobalAddrSpace));
             Value *GToF = Builder.CreateAddrSpaceCast(FToG, PArg->getType());
 
-            Tmp->replaceAllUsesWith(GToF);
+            Tmp.replaceAllUsesWith(GToF);
         });
 
         return true;


### PR DESCRIPTION
Leaving ancient hacks around like the HCC triple based one is unwise. It is similarly unwise to `new` when you do not need it, especially without `delete`ing