### PR TITLE
do not traverse callgraph during pass initialization

### DIFF
--- a/lib/Transforms/HC/SelectAcceleratorCode/SelectAcceleratorCode.cpp
+++ b/lib/Transforms/HC/SelectAcceleratorCode/SelectAcceleratorCode.cpp
@@ -121,8 +121,12 @@ public:
     static char ID;
     SelectAcceleratorCode() : ModulePass{ID} {}
 
-    bool doInitialization(Module &M) override
-    {   // TODO: this may represent a valid analysis pass.
+    bool doInitialization(Module &M) override {}
+
+    bool runOnModule(Module &M) override {
+    {
+        // This may be a candidate for an analysis pass that is
+        // invalidated appropriately by other passes.
         for (auto&& F : M.functions()) {
             if (F.getCallingConv() == CallingConv::AMDGPU_KERNEL) {
                  auto Tmp = HCCallees_.insert(M.getFunction(F.getName()));
@@ -130,11 +134,6 @@ public:
             }
         }
 
-        return false;
-    }
-
-    bool runOnModule(Module &M) override
-    {
         bool Modified = eraseNonHCFunctions_(M);
 
         Modified = eraseDeadGlobals_(M) || Modified;


### PR DESCRIPTION
The initializer for SelectAcceleratorCode traverses the call-graph to
create a list of functions that are called on the device side. But
this stage is too early, since other passes can change the call-graph
before the pass actually runs.

Hence moving the traversal to runOnModule().