### PR TITLE
SelectAcceleratorCode: strip pointer casts when examining a call

### DIFF
--- a/lib/Transforms/HC/SelectAcceleratorCode/SelectAcceleratorCode.cpp
+++ b/lib/Transforms/HC/SelectAcceleratorCode/SelectAcceleratorCode.cpp
@@ -38,10 +38,10 @@ class SelectAcceleratorCode : public ModulePass {
     {
         for (auto&& BB : F) {
             for (auto&& I : BB) {
-                if (I.getOpcode() == Instruction::Call) {
-                    auto Callee = cast<CallInst>(I).getCalledFunction();
-                    if (Callee) {
-                        auto Tmp = HCCallees_.insert(M.getFunction(Callee->getName()));
+                if (auto CI = dyn_cast<CallInst>(&I)) {
+                    auto V = CI->getCalledValue()->stripPointerCasts();
+                    if (auto Callee = dyn_cast<Function>(V)) {
+                        auto Tmp = HCCallees_.insert(Callee);
                         if (Tmp.second) findAllHCCallees_(*Callee, M);
                     }
                 }


### PR DESCRIPTION
At a call-site, the callee may not directly be a pointer to the
function; it can also be a cast expression even that points to the
actual function. This can happen even without an indirect call. The
traversal of the call-graph needs to be aware of such pointer casts.