### PR TITLE
moved the skip branch insertion code for correctness upfront

### DIFF
--- a/lib/Target/AMDGPU/SIInstrInfo.cpp
+++ b/lib/Target/AMDGPU/SIInstrInfo.cpp
@@ -2677,6 +2677,19 @@ bool SIInstrInfo::isAlwaysGDS(uint16_t Opcode) const {
          Opcode == AMDGPU::DS_GWS_BARRIER;
 }
 
+bool SIInstrInfo::opcodeEmitsNoInsts(const MachineInstr &MI) const {
+  if (MI.isMetaInstruction())
+    return true;
+
+  // Handle target specific opcodes.
+  switch (MI.getOpcode()) {
+  case AMDGPU::SI_MASK_BRANCH:
+    return true;
+  default:
+    return false;
+  }
+}
+
 bool SIInstrInfo::hasUnwantedEffectsWhenEXECEmpty(const MachineInstr &MI) const {
   unsigned Opcode = MI.getOpcode();
 

--- a/lib/Target/AMDGPU/SIInstrInfo.h
+++ b/lib/Target/AMDGPU/SIInstrInfo.h
@@ -668,6 +668,9 @@ public:
       return MO.isReg() && RI.isVGPR(MRI, MO.getReg());});
   }
 
+  /// returns true if \p MI won't emit an instruction in the end.
+  bool opcodeEmitsNoInsts(const MachineInstr &MI) const;
+
   /// Whether we must prevent this instruction from executing with EXEC = 0.
   bool hasUnwantedEffectsWhenEXECEmpty(const MachineInstr &MI) const;
 


### PR DESCRIPTION
Skip branch instruction insertion is mandatory for certain scenarios. Moved the code deal with such scenarios upfront during SILowerControlFlow from SIInsertSkips. Now SIInsertSkips contain the insertion based on the skip-threshold value.
